### PR TITLE
Change the behavior of bounds.height "percentage"

### DIFF
--- a/dist/tinycrop.js
+++ b/dist/tinycrop.js
@@ -198,7 +198,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      if (isInteger(boundsHeight)) {
 	        height = boundsHeight;
 	      } else if (isPercent(boundsHeight)) {
-	        height = Math.round(width * getPercent(boundsHeight) / 100);
+	        height = Math.round(parent.clientHeight * getPercent(boundsHeight) / 100);
 	      } else if (image && image.hasLoaded && isAuto(boundsHeight)) {
 	        height = Math.floor(width / image.getAspectRatio());
 	      } else {


### PR DESCRIPTION
It makes the bounds.height "percentage" to be a percentage of the parent.clientHeight instead of a percentage of the bounds.width.